### PR TITLE
Fix category update and login response bugs

### DIFF
--- a/backend/routes/categories.js
+++ b/backend/routes/categories.js
@@ -38,11 +38,17 @@ router.post('/', async (req,res)=>{
 
 
 router.put('/:id',async (req, res)=> {
+    // Find existing category to preserve values if not provided
+    const existingCategory = await Category.findById(req.params.id);
+    if(!existingCategory) {
+        return res.status(400).send('Invalid Category')
+    }
+
     const category = await Category.findByIdAndUpdate(
         req.params.id,
         {
             name: req.body.name,
-            icon: req.body.icon || category.icon,
+            icon: req.body.icon || existingCategory.icon,
             color: req.body.color,
         },
         { new: true}

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -62,10 +62,8 @@ router.post('/login', async(req,res) => {
         )        
         res.status(200).send({user: user.email, token: token});
     } else{
-        res.status(400).send('The password is incorrect');
+        return res.status(400).send('The password is incorrect');
     }
-
-    return res.status(200).send(user);
     
 })
 


### PR DESCRIPTION
## Summary
- fix category update route by fetching existing data before update
- remove extraneous response in login route

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` in easy-shop (fails: Missing script: test)


------
https://chatgpt.com/codex/tasks/task_e_6840dca22430832180e05bd0c358c406